### PR TITLE
Add text similarity feedback score fields to ReCiterArticle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.cornell.weill.reciter</groupId>
   <artifactId>reciter-article-model</artifactId>
-  <version>2.0.32-SNAPSHOT</version>
+  <version>2.0.33-SNAPSHOT</version>
   <name>ReCiter-Article-Model</name>
   <description>A set of classes representing an identity</description>
     <url>https://github.com/wcmc-its/ReCiter-Article-Model</url>

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,19 @@
 	        <plugins>
 	            <plugin>
 	                <artifactId>maven-compiler-plugin</artifactId>
-	                <version>3.8.1</version>
+	                <version>3.11.0</version>
 	                <configuration>
 	                    <encoding>UTF-8</encoding>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
 						<showDeprecation>true</showDeprecation>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>1.18.44</version>
+							</path>
+						</annotationProcessorPaths>
 	                </configuration>
 	            </plugin>
 	            <plugin>
@@ -186,7 +193,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.44</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/reciter/model/article/ReCiterArticle.java
+++ b/src/main/java/reciter/model/article/ReCiterArticle.java
@@ -103,6 +103,7 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
     private double orcidFeedbackScore;
     private double orcidCoAuthorFeedbackScore;
     private double citesFeedbackScore;
+    private double bibliographicCouplingFeedbackScore;
     private double emailFeedbackScore;
     private double institutionFeedbackScore;
     private double organizationFeedbackScore;
@@ -120,6 +121,7 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
     private String exportedOrcidFeedbackScore;
     private String exportedOrcidCoAuthorFeedbackScore;
     private String exportedCitesFeedbackScore;
+    private String exportedBibliographicCouplingFeedbackScore;
     private String exportedEmailFeedbackScore;
     private String exportedInstitutionFeedbackScore;
     private String exportedOrganizationFeedbackScore;
@@ -1100,6 +1102,14 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 		this.citesFeedbackScore = citesFeedbackScore;
 	}
 
+	public double getBibliographicCouplingFeedbackScore() {
+		return bibliographicCouplingFeedbackScore;
+	}
+
+	public void setBibliographicCouplingFeedbackScore(double bibliographicCouplingFeedbackScore) {
+		this.bibliographicCouplingFeedbackScore = bibliographicCouplingFeedbackScore;
+	}
+
 	public double getEmailFeedbackScore() {
 		return emailFeedbackScore;
 	}
@@ -1234,6 +1244,14 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 
 	public void setExportedCitesFeedbackScore(String exportedCitesFeedbackScore) {
 		this.exportedCitesFeedbackScore = exportedCitesFeedbackScore;
+	}
+
+	public String getExportedBibliographicCouplingFeedbackScore() {
+		return exportedBibliographicCouplingFeedbackScore;
+	}
+
+	public void setExportedBibliographicCouplingFeedbackScore(String exportedBibliographicCouplingFeedbackScore) {
+		this.exportedBibliographicCouplingFeedbackScore = exportedBibliographicCouplingFeedbackScore;
 	}
 
 	public String getExportedEmailFeedbackScore() {

--- a/src/main/java/reciter/model/article/ReCiterArticle.java
+++ b/src/main/java/reciter/model/article/ReCiterArticle.java
@@ -108,6 +108,8 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
     private double organizationFeedbackScore;
     private double targetAuthorNameFeedbackScore;
     private double yearFeedbackScore;
+    private double textSimilarityFeedbackScore;
+    private double journalTitleSimilarityFeedbackScore;
     private double feedbackTotalScore;
     private String exportedCoAuthorNameFeedbackScore;
     private String exportedKeywordFeedackScore;
@@ -122,7 +124,9 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
     private String exportedInstitutionFeedbackScore;
     private String exportedOrganizationFeedbackScore;
     private String exportedTargetAuthorNameFeedbackScore;
-    private String exportedYearFeedbackScore; 
+    private String exportedYearFeedbackScore;
+    private String exportedTextSimilarityFeedbackScore;
+    private String exportedJournalTitleSimilarityFeedbackScore;
     private List<Map<String,List<ReCiterArticleFeedbackScore>>> articleFeedbackScoresMapList;
     private double authorshipLikelihoodScore;
     
@@ -1136,6 +1140,22 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 		this.yearFeedbackScore = yearFeedbackScore;
 	}
 
+	public double getTextSimilarityFeedbackScore() {
+		return textSimilarityFeedbackScore;
+	}
+
+	public void setTextSimilarityFeedbackScore(double textSimilarityFeedbackScore) {
+		this.textSimilarityFeedbackScore = textSimilarityFeedbackScore;
+	}
+
+	public double getJournalTitleSimilarityFeedbackScore() {
+		return journalTitleSimilarityFeedbackScore;
+	}
+
+	public void setJournalTitleSimilarityFeedbackScore(double journalTitleSimilarityFeedbackScore) {
+		this.journalTitleSimilarityFeedbackScore = journalTitleSimilarityFeedbackScore;
+	}
+
 	public double getJournalFeedackScore() {
 		return journalFeedackScore;
 	}
@@ -1254,6 +1274,22 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 
 	public void setExportedYearFeedbackScore(String exportedYearFeedbackScore) {
 		this.exportedYearFeedbackScore = exportedYearFeedbackScore;
+	}
+
+	public String getExportedTextSimilarityFeedbackScore() {
+		return exportedTextSimilarityFeedbackScore;
+	}
+
+	public void setExportedTextSimilarityFeedbackScore(String exportedTextSimilarityFeedbackScore) {
+		this.exportedTextSimilarityFeedbackScore = exportedTextSimilarityFeedbackScore;
+	}
+
+	public String getExportedJournalTitleSimilarityFeedbackScore() {
+		return exportedJournalTitleSimilarityFeedbackScore;
+	}
+
+	public void setExportedJournalTitleSimilarityFeedbackScore(String exportedJournalTitleSimilarityFeedbackScore) {
+		this.exportedJournalTitleSimilarityFeedbackScore = exportedJournalTitleSimilarityFeedbackScore;
 	}
 
 	public List<Map<String,List<ReCiterArticleFeedbackScore>>> getArticleFeedbackScoresMap() {

--- a/src/main/java/reciter/model/article/ReCiterArticleFeedbackIdentityScore.java
+++ b/src/main/java/reciter/model/article/ReCiterArticleFeedbackIdentityScore.java
@@ -13,6 +13,8 @@ public class ReCiterArticleFeedbackIdentityScore {
 	private double feedbackScoreJournal;
 	private double feedbackScoreJournalSubField;
 	private double feedbackScoreKeyword;
+	private double feedbackScoreTextSimilarity;
+	private double feedbackScoreJournalTitleSimilarity;
 	private double feedbackScoreOrcid;
 	private double feedbackScoreOrcidCoAuthor;
 	private double feedbackScoreOrganization;
@@ -82,6 +84,7 @@ public class ReCiterArticleFeedbackIdentityScore {
 	public ReCiterArticleFeedbackIdentityScore(long articleId, double feedbackScoreCites,
 			double feedbackScoreCoAuthorName, double feedbackScoreEmail, double feedbackScoreInstitution,
 			double feedbackScoreJournal, double feedbackScoreJournalSubField, double feedbackScoreKeyword,
+			double feedbackScoreTextSimilarity, double feedbackScoreJournalTitleSimilarity,
 			double feedbackScoreOrcid, double feedbackScoreOrcidCoAuthor, double feedbackScoreOrganization,
 			double feedbackScoreTargetAuthorName, double feedbackScoreYear,
 			double feedbackScoreBibliographicCoupling, double articleCountScore,double authorCountScore,
@@ -102,6 +105,8 @@ public class ReCiterArticleFeedbackIdentityScore {
 	        this.feedbackScoreJournal = feedbackScoreJournal;
 	        this.feedbackScoreJournalSubField = feedbackScoreJournalSubField;
 	        this.feedbackScoreKeyword = feedbackScoreKeyword;
+	        this.feedbackScoreTextSimilarity = feedbackScoreTextSimilarity;
+	        this.feedbackScoreJournalTitleSimilarity = feedbackScoreJournalTitleSimilarity;
 	        this.feedbackScoreOrcid = feedbackScoreOrcid;
 	        this.feedbackScoreOrcidCoAuthor = feedbackScoreOrcidCoAuthor;
 	        this.feedbackScoreOrganization = feedbackScoreOrganization;

--- a/src/main/java/reciter/model/article/ReCiterArticleFeedbackIdentityScore.java
+++ b/src/main/java/reciter/model/article/ReCiterArticleFeedbackIdentityScore.java
@@ -18,6 +18,7 @@ public class ReCiterArticleFeedbackIdentityScore {
 	private double feedbackScoreOrganization;
 	private double feedbackScoreTargetAuthorName;
 	private double feedbackScoreYear;
+	private double feedbackScoreBibliographicCoupling;
 	private double articleCountScore;
 	private double authorCountScore;
 	private double discrepancyDegreeYearScore;
@@ -82,7 +83,8 @@ public class ReCiterArticleFeedbackIdentityScore {
 			double feedbackScoreCoAuthorName, double feedbackScoreEmail, double feedbackScoreInstitution,
 			double feedbackScoreJournal, double feedbackScoreJournalSubField, double feedbackScoreKeyword,
 			double feedbackScoreOrcid, double feedbackScoreOrcidCoAuthor, double feedbackScoreOrganization,
-			double feedbackScoreTargetAuthorName, double feedbackScoreYear, double articleCountScore,double authorCountScore,
+			double feedbackScoreTargetAuthorName, double feedbackScoreYear,
+			double feedbackScoreBibliographicCoupling, double articleCountScore,double authorCountScore,
 			double discrepancyDegreeYearScore, double emailMatchScore, double genderScoreIdentityArticleDiscrepancy,
 			double grantMatchScore, double journalSubfieldScore, double nameMatchFirstScore, double nameMatchLastScore,
 			double nameMatchMiddleScore, double nameMatchModifierScore, double organizationalUnitMatchingScore,
@@ -105,6 +107,7 @@ public class ReCiterArticleFeedbackIdentityScore {
 	        this.feedbackScoreOrganization = feedbackScoreOrganization;
 	        this.feedbackScoreTargetAuthorName = feedbackScoreTargetAuthorName;
 	        this.feedbackScoreYear = feedbackScoreYear;
+	        this.feedbackScoreBibliographicCoupling = feedbackScoreBibliographicCoupling;
 	        this.articleCountScore = articleCountScore;
 	        this.authorCountScore = authorCountScore;
 	        this.discrepancyDegreeYearScore = discrepancyDegreeYearScore;


### PR DESCRIPTION
## Summary
- Add `textSimilarityFeedbackScore` and `journalTitleSimilarityFeedbackScore` fields (double + exported String) to `ReCiterArticle`
- Follows the exact same pattern as the 14 existing feedback score fields
- Bump version to 2.0.33-SNAPSHOT
- Required by ReCiter PR #585 (`feature/text-similarity-feedback`), which added `TextSimilarityFeedbackStrategy` and `JournalTitleSimilarityFeedbackStrategy` — currently `development` branch doesn't compile because these fields are missing from the article model

## Test plan
- [ ] Verify `mvn compile` passes (requires Java 8/11 due to Lombok)
- [ ] After merge + Maven Central publish, update ReCiter `pom.xml` to 2.0.33 and confirm `development` compiles
