### PR TITLE
Add v3 feedback score fields to FeedbackEvidence DTO

### DIFF
--- a/src/main/java/reciter/engine/analysis/evidence/FeedbackEvidence.java
+++ b/src/main/java/reciter/engine/analysis/evidence/FeedbackEvidence.java
@@ -24,4 +24,7 @@ public class FeedbackEvidence {
 	private Double feedbackScoreOrganization;
 	private Double feedbackScoreTargetAuthorName;
 	private Double feedbackScoreYear;
+	private Double feedbackScoreTextSimilarity;
+	private Double feedbackScoreJournalTitleSimilarity;
+	private Double feedbackScoreBibliographicCoupling;
 }


### PR DESCRIPTION
## Summary

- Adds 3 missing fields to `FeedbackEvidence.java`: `feedbackScoreTextSimilarity`, `feedbackScoreJournalTitleSimilarity`, `feedbackScoreBibliographicCoupling`
- These v3 feedback scores are already computed by Java and written to S3 for Lambda scoring, but were never added to the response DTO — so the Feature Generator API response doesn't include them and Publication Manager can't display them
- Also includes prior commits on this branch: text similarity fields on ReCiterArticle, bibliographic coupling fields, Lombok JDK 17 fix

## After merge

Publish a new version to Maven Central, then ReCiter `development` pom will be updated to reference it.