### PR TITLE
Add commentsCorrectionsRefTypes field to ReCiterArticle

### DIFF
--- a/src/main/java/reciter/model/article/ReCiterArticle.java
+++ b/src/main/java/reciter/model/article/ReCiterArticle.java
@@ -19,6 +19,7 @@
 package reciter.model.article;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -215,6 +216,7 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 
     private int goldStandard;
     private Set<Long> commentsCorrectionsPmids = new HashSet<>();
+    private Map<Long, String> commentsCorrectionsRefTypes = new HashMap<>();
     private List<ReCiterArticleMeshHeading> meshHeadings = new ArrayList<>();
 
     private List<ReCiterAuthor> knownRelationships = new ArrayList<>();
@@ -756,6 +758,14 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 
     public void setCommentsCorrectionsPmids(Set<Long> commentsCorrectionsPmids) {
         this.commentsCorrectionsPmids = commentsCorrectionsPmids;
+    }
+
+    public Map<Long, String> getCommentsCorrectionsRefTypes() {
+        return commentsCorrectionsRefTypes;
+    }
+
+    public void setCommentsCorrectionsRefTypes(Map<Long, String> commentsCorrectionsRefTypes) {
+        this.commentsCorrectionsRefTypes = commentsCorrectionsRefTypes;
     }
 
     public List<ReCiterArticleMeshHeading> getMeshHeadings() {


### PR DESCRIPTION
## Summary

Adds a `Map<Long, String> commentsCorrectionsRefTypes` field to `ReCiterArticle` with getter/setter. This maps each CommentsCorrections PMID to its PubMed reference type (e.g., `CommentOn`, `ErratumFor`, `RetractionOf`).

**Required by:** ReCiter PR #596 (pub type classifier re-add) — `ArticleTranslator.java` populates this field, and the classifier uses it for Phase 1 conditioning.

**After merging:** Publish to Maven so ReCiter can resolve the dependency. ReCiter `pom.xml` already references `reciter-article-model` version `2.0.34`.

## Changes

One file: `ReCiterArticle.java`
- Added `HashMap` import
- Added field declaration (line 219)
- Added getter/setter (after line 761)
