### PR TITLE
Add datePublicationAddedToPMC field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.cornell.weill.reciter</groupId>
   <artifactId>reciter-article-model</artifactId>
-  <version>2.0.35</version>
+  <version>2.0.36</version>
   <name>ReCiter-Article-Model</name>
   <description>A set of classes representing an identity</description>
     <url>https://github.com/wcmc-its/ReCiter-Article-Model</url>

--- a/src/main/java/reciter/engine/analysis/ReCiterArticleFeature.java
+++ b/src/main/java/reciter/engine/analysis/ReCiterArticleFeature.java
@@ -25,6 +25,7 @@ public class ReCiterArticleFeature {
     private String publicationDateDisplay;
     private String publicationDateStandardized;
     private String datePublicationAddedToEntrez;
+    private String datePublicationAddedToPMC;
     private String doi;
     private ReCiterArticlePublicationType publicationType;
     private Long timesCited;

--- a/src/main/java/reciter/model/article/ReCiterArticle.java
+++ b/src/main/java/reciter/model/article/ReCiterArticle.java
@@ -240,7 +240,9 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
     private String publicationDateStandardized;
     
     private String datePublicationAddedToEntrez;
-    
+
+    private String datePublicationAddedToPMC;
+
     private String publicationDateDisplay;
     
     
@@ -392,6 +394,14 @@ public class ReCiterArticle implements Comparable<ReCiterArticle> {
 
 	public void setDatePublicationAddedToEntrez(String datePublicationAddedToEntrez) {
 		this.datePublicationAddedToEntrez = datePublicationAddedToEntrez;
+	}
+
+	public String getDatePublicationAddedToPMC() {
+		return datePublicationAddedToPMC;
+	}
+
+	public void setDatePublicationAddedToPMC(String datePublicationAddedToPMC) {
+		this.datePublicationAddedToPMC = datePublicationAddedToPMC;
 	}
 
 	public String getPublicationDateDisplay() {


### PR DESCRIPTION
## Summary
- Add `datePublicationAddedToPMC` field to `ReCiterArticle` and `ReCiterArticleFeature`
- This carries the PubMed `pmc-release` date (when an article becomes freely available in PMC) through the pipeline
- Bump version to 2.0.36

## Context
The PubMed Retrieval Tool already parses the `<PubMedPubDate PubStatus="pmc-release">` entry from PubMed XML into the History list. This adds a dedicated field so downstream components (ReCiter, ReciterDB) can surface it as a named column.

## Test plan
- [ ] Build passes (`mvn clean install`)
- [ ] Companion PR in ReCiter extracts and populates this field